### PR TITLE
Update package to use Fractal 0.13.0 with JsonApiSerializer changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php" : ">=5.5.0",
-        "league/fractal": "^0.12.0",
+        "league/fractal": "^0.13.0",
         "illuminate/support": "^5.1"
     },
     "require-dev": {

--- a/tests/Integration/PaginatorTest.php
+++ b/tests/Integration/PaginatorTest.php
@@ -24,7 +24,13 @@ class PaginatorTest extends TestCase
 
         $expectedArray = [
             'data' => [
-                ['id' => 1, 'author' => 'Philip K Dick'],
+                [
+                    'id' => 1,
+                    'type' => null,
+                    'attributes' => [
+                        'author' => 'Philip K Dick'
+                    ],
+                ],
             ],
             'meta' => [
                 'pagination' => [

--- a/tests/Integration/ResourceNameTest.php
+++ b/tests/Integration/ResourceNameTest.php
@@ -17,9 +17,21 @@ class ResourceNameTest extends TestCase
             ->toArray();
 
         $expectedArray = [
-            'books' => [
-                ['id' => 1, 'author' => 'Philip K Dick'],
-                ['id' => 2, 'author' => 'George R. R. Satan'],
+            'data' => [
+                [
+                    'id' => 1,
+                    'type' => 'books',
+                    'attributes' => [
+                        'author' => 'Philip K Dick',
+                    ],
+                ],
+                [
+                    'id' => 2,
+                    'type' => 'books',
+                    'attributes' => [
+                        'author' => 'George R. R. Satan',
+                    ],
+                ],
             ],
         ];
 
@@ -38,9 +50,21 @@ class ResourceNameTest extends TestCase
             ->toArray();
 
         $expectedArray = [
-            'books' => [
-                ['id' => 1, 'author' => 'Philip K Dick'],
-                ['id' => 2, 'author' => 'George R. R. Satan'],
+            'data' => [
+                [
+                    'id' => 1,
+                    'type' => 'books',
+                    'attributes' => [
+                        'author' => 'Philip K Dick',
+                    ],
+                ],
+                [
+                    'id' => 2,
+                    'type' => 'books',
+                    'attributes' => [
+                        'author' => 'George R. R. Satan',
+                    ],
+                ],
             ],
         ];
 
@@ -59,8 +83,12 @@ class ResourceNameTest extends TestCase
             ->toArray();
 
         $expectedArray = [
-            'book' => [
-                ['id' => 1, 'author' => 'Philip K Dick'],
+            'data' => [
+                'id' => 1,
+                'type' => 'book',
+                'attributes' => [
+                    'author' => 'Philip K Dick',
+                ],
             ],
         ];
 
@@ -70,7 +98,7 @@ class ResourceNameTest extends TestCase
     /**
      * @test
      */
-    public function it_uses_data_as_resource_name_when_not_set()
+    public function it_uses_null_as_resource_name_when_not_set()
     {
         $array = $this->fractal
             ->collection($this->testBooks, new TestTransformer())
@@ -79,8 +107,20 @@ class ResourceNameTest extends TestCase
 
         $expectedArray = [
             'data' => [
-                ['id' => 1, 'author' => 'Philip K Dick'],
-                ['id' => 2, 'author' => 'George R. R. Satan'],
+                [
+                    'id' => 1,
+                    'type' => null,
+                    'attributes' => [
+                        'author' => 'Philip K Dick',
+                    ],
+                ],
+                [
+                    'id' => 2,
+                    'type' => null,
+                    'attributes' => [
+                        'author' => 'George R. R. Satan',
+                    ],
+                ],
             ],
         ];
 


### PR DESCRIPTION
I was trying to use Fractal's JsonApiSerializer with this package, and it wasn't playing nicely with the 1.0 spec. Realized Fractal was updated 3 days ago, so I updated Fractal and the newly failing tests.

Let me know if I need to change anything or do anything differently to contribute!