### PR TITLE
Added functionality to set default_serializer as an instantiation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ return [
 
     /*
      * The default serializer to be used when performing a transformation.
-     * Leave empty to use the Fractal's default.
+     * Leave empty to use the Fractal's default. This can be a string or
+     * it can be an instance of League\Fractal\Serializer\SerializerAbstract
      */
     'default_serializer' => '',
 ];
@@ -181,7 +182,7 @@ fractal()
 
 ### Changing the default serializer
 
-You can change the default serializer by providing the classname of your favorite serializer in
+You can change the default serializer by providing the classname or an instantiation of your favorite serializer in
 the config file.
 
 ## Using includes

--- a/resources/config/laravel-fractal.php
+++ b/resources/config/laravel-fractal.php
@@ -4,7 +4,8 @@ return [
 
     /*
      * The default serializer to be used when performing a transformation.
-     * Leave empty to use the Fractal's default.
+     * Leave empty to use the Fractal's default. This can be a string or
+     * it can be an instance of League\Fractal\Serializer\SerializerAbstract
      */
     'default_serializer' => '',
 ];

--- a/src/FractalServiceProvider.php
+++ b/src/FractalServiceProvider.php
@@ -4,6 +4,7 @@ namespace Spatie\Fractal;
 
 use Illuminate\Support\ServiceProvider;
 use League\Fractal\Manager;
+use League\Fractal\Serializer\SerializerAbstract;
 
 class FractalServiceProvider extends ServiceProvider
 {
@@ -32,8 +33,12 @@ class FractalServiceProvider extends ServiceProvider
 
             $config = $this->app['config']->get('laravel-fractal');
 
-            if ($config['default_serializer'] != '') {
-                $fractal->serializeWith(new $config['default_serializer']());
+            if ( ! empty($config['default_serializer'])) {
+                if ($config['default_serializer'] instanceof SerializerAbstract) {
+                    $fractal->serializeWith($config['default_serializer']);
+                } else {
+                    $fractal->serializeWith(new $config['default_serializer']());
+                }
             }
 
             return $fractal;

--- a/tests/Integration/DefaultSerializerObjectTest.php
+++ b/tests/Integration/DefaultSerializerObjectTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\Fractal\Test\Integration;
+
+use League\Fractal\Serializer\JsonApiSerializer;
+
+class DefaultSerializerObjectTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp(new JsonApiSerializer());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_use_an_instantiated_serializer_as_a_default()
+    {
+        $array = $this->fractal
+            ->collection($this->testBooks, new TestTransformer(), 'books')
+            ->toArray();
+
+        $expectedArray = [
+            'data' => [
+                [
+                    'id' => 1,
+                    'type' => 'books',
+                    'attributes' => [
+                        'author' => 'Philip K Dick',
+                    ],
+                ],
+                [
+                    'id' => 2,
+                    'type' => 'books',
+                    'attributes' => [
+                        'author' => 'George R. R. Satan',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedArray, $array);
+    }
+}

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends Orchestra
     protected $testBooks;
 
     /**
-     * @var string
+     * @var string|\League\Fractal\Serializer\SerializerAbstract
      */
     protected $defaultSerializer;
 


### PR DESCRIPTION
This should be a non-breaking addition to allow for the default_serializer config value to be set as a SerializerAbstract object. It gives developers more flexibility in how the default serializer can be used.

In my case, I want to be able to have the default serializer as `JsonApiSerializer` and for it to set the `"links"` key in the response, so I need to be able to send a `$baseUrl` parameter to the serializer.

Let me know if I need to rework anything.