### PR TITLE
Fix parseIncludes to allow multiple includes in one go

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -155,7 +155,7 @@ class Fractal
     public function parseIncludes($includes)
     {
         if (is_string($includes)) {
-            $includes = [$includes];
+            $includes = explode(',', $includes);
         }
 
         $this->includes = array_merge($this->includes, $includes);

--- a/tests/Integration/IncludesTest.php
+++ b/tests/Integration/IncludesTest.php
@@ -58,4 +58,22 @@ class IncludesTest extends TestCase
 
         $this->assertEquals($expectedArray, $array);
     }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_multiple_includes_at_once()
+    {
+        $array = $this->fractal
+            ->collection($this->testBooks, new TestTransformer())
+            ->parseIncludes('characters,publisher')
+            ->toArray();
+
+        $expectedArray = ['data' => [
+            ['id' => 1, 'author' => 'Philip K Dick',  'characters' => ['data' => ['Death', 'Hex']], 'publisher' => ['data' => ['Elephant books']]],
+            ['id' => 2, 'author' => 'George R. R. Satan', 'characters' => ['data' => ['Ned Stark', 'Tywin Lannister']], 'publisher' => ['data' => ['Bloody Fantasy inc.']]],
+        ]];
+
+        $this->assertEquals($expectedArray, $array);
+    }
 }


### PR DESCRIPTION
The `parseIncludes` is not working as expected by Fractal.
If your includes contain multiple fields (author,comments) it will fail, cause its converting the entire string to array instead of exploding.
Thanks