### PR TITLE
fixes behaviour for passing empty values to parseIncludes

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -160,7 +160,7 @@ class Fractal
             },  explode(',', $includes));
         }
 
-        $this->includes = array_merge($this->includes, $includes);
+        $this->includes = array_merge($this->includes, (array)$includes);
 
         return $this;
     }

--- a/tests/Integration/IncludesTest.php
+++ b/tests/Integration/IncludesTest.php
@@ -82,4 +82,28 @@ class IncludesTest extends TestCase
 
         $this->assertEquals($expectedArray, $array);
     }
+
+    /**
+     * @test
+     */
+    public function it_knows_to_ignore_invalid_includes_param()
+    {
+        $array = $this->fractal
+            ->collection($this->testBooks, new TestTransformer())
+            ->parseIncludes(null)
+            ->toArray();
+
+        $expectedArray = ['data' => [
+            ['id' => 1, 'author' => 'Philip K Dick', ],
+            ['id' => 2, 'author' => 'George R. R. Satan', ],
+        ]];
+
+        $this->assertEquals($expectedArray, $array);
+
+        $array = $this->fractal
+            ->collection($this->testBooks, new TestTransformer())
+            ->parseIncludes([])
+            ->toArray();
+        $this->assertEquals($expectedArray, $array);
+    }
 }


### PR DESCRIPTION
I got:

    ErrorException in Fractal.php line 163:
    array_merge(): Argument #2 is not an array

after doing:

    Fractal::collection($data, new $transformerClass, $transformerClass::TYPE)->parseIncludes(Input::get('expand'))->toJson();

I think that this is so common that the method should account for `null` or anything other than array and string.