### PR TITLE
implement JsonSerializable interface

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -2,13 +2,14 @@
 
 namespace Spatie\Fractal;
 
+use JsonSerializable;
 use League\Fractal\Manager;
 use League\Fractal\Pagination\PaginatorInterface;
 use League\Fractal\Serializer\SerializerAbstract;
 use Spatie\Fractal\Exceptions\InvalidTransformation;
 use Spatie\Fractal\Exceptions\NoTransformerSpecified;
 
-class Fractal
+class Fractal implements JsonSerializable
 {
     /**
      * @var \League\Fractal\Manager
@@ -318,5 +319,15 @@ class Fractal
         }
 
         return $resource;
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
     }
 }

--- a/tests/Integration/FractalTest.php
+++ b/tests/Integration/FractalTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Fractal\Test\Integration;
 
+use Illuminate\Http\JsonResponse;
+
 class FractalTest extends TestCase
 {
     /**
@@ -108,5 +110,18 @@ class FractalTest extends TestCase
             ->createData();
 
         $this->assertInstanceOf(\League\Fractal\Scope::class, $resource);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_handled_by_response_without_using_a_transformer_to_array()
+    {
+        $json = $this->fractal->collection($this->testBooks, new TestTransformer());
+        $response = new JsonResponse($json);
+
+        $expectedJson = '{"data":[{"id":1,"author":"Philip K Dick"},{"id":2,"author":"George R. R. Satan"}]}';
+
+        $this->assertEquals($expectedJson, $response->getContent());
     }
 }


### PR DESCRIPTION
Sometimes you just want this.

```php
return response()->json(
    fractal()->item($data, new TestTransformer())
);
```

Without `->toArray()`.