### PR TITLE
Added a command for a quick transformer creation

### DIFF
--- a/src/Console/Commands/TransformerMakeCommand.php
+++ b/src/Console/Commands/TransformerMakeCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\Fractal\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+
+class TransformerMakeCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'make:transformer';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Makes a Fractal transformer.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Transformer';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/../stubs/transformer.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Transformers';
+    }
+}

--- a/src/Console/stubs/transformer.stub
+++ b/src/Console/stubs/transformer.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace DummyNamespace;
+
+use League\Fractal\TransformerAbstract;
+
+class DummyClass extends TransformerAbstract
+{
+    /**
+     * A Fractal transformer.
+     *
+     * @return array
+     */
+    public function transform()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/FractalServiceProvider.php
+++ b/src/FractalServiceProvider.php
@@ -5,6 +5,7 @@ namespace Spatie\Fractal;
 use Illuminate\Support\ServiceProvider;
 use League\Fractal\Manager;
 use League\Fractal\Serializer\SerializerAbstract;
+use Spatie\Fractal\Console\Commands\TransformerMakeCommand;
 
 class FractalServiceProvider extends ServiceProvider
 {
@@ -16,6 +17,12 @@ class FractalServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../resources/config/laravel-fractal.php' => config_path('laravel-fractal.php'),
         ], 'config');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                TransformerMakeCommand::class,
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
Added a `make:transformer` command to quickly scaffold a transformer in `app/Transformers/` directory.