### PR TITLE
Fractal response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ build
 composer.lock
 docs
 vendor
-phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+phpunit.xml

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
 
 $books = [
-   ['id'=>1, 'title'=>'Hogfather', 'characters' => [...]], 
+   ['id'=>1, 'title'=>'Hogfather', 'characters' => [...]],
    ['id'=>2, 'title'=>'Game Of Kill Everyone', 'characters' => [...]]
 ];
 
@@ -52,7 +52,7 @@ There's also a very short syntax available to quickly transform data:
 fractal($books, new BookTransformer())->toArray();
 ```
 
-Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all 
+Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all
 our open source projects [on our website](https://spatie.be/opensource).
 
 ## Postcardware
@@ -91,7 +91,7 @@ If you want to make use of the facade you must install it as well:
 ];
 ```
 
-If you want to [change the default serializer](https://github.com/spatie/laravel-fractal#changing-the-default-serializer), 
+If you want to [change the default serializer](https://github.com/spatie/laravel-fractal#changing-the-default-serializer),
 you must publish the config file:
 
 ```bash
@@ -124,6 +124,45 @@ return [
 Refer to [the documentation of `spatie/fractalistic`](https://github.com/spatie/fractalistic) to learn all the methods this package provides.
 
 In all code examples you may use `fractal()` instead of `Fractal::create()`.
+
+## Attaching a status code and headers
+
+Now you can easily create fractal responses with status codes and headers.
+
+Previously what you might have done is this ugly JSON response just to attach a response code or headers:
+```php
+return response()->json(
+    fractal()
+        ->item('These credentials do not match our records.')
+        ->transformWith(new ErrorTransformer)
+        ->serializeWith(new ArraySerializer)
+        ->toArray()
+, 433, $headers);
+```
+now, you can easily chain on the status code inside the `respond()` method:
+```php
+return fractal()
+    ->item('These credentials do not match our records.')
+    ->transformWith(new ErrorTransformer)
+    ->serializeWith(new ArraySerializer)
+    ->respond(433, $headers);
+```
+
+If you have some complicated headers' or status code's connected logic, you can do it in a callback like so:
+```php
+return fractal()
+    ->item('These credentials do not match our records.')
+    ->transformWith(new ErrorTransformer)
+    ->serializeWith(new ArraySerializer)
+    ->respond(function ($response) {
+        $response->code(433)
+            ->header('test-header', 'test-value')
+            ->headers([
+                'test2-header' => 'test2-value',
+            ]);
+    });
+```
+
 
 ## Quickly creating a transformer
 

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -23,8 +23,9 @@ class Fractal extends Fractalistic
             $callbackOrStatusCode($this->response);
         } else {
             $this->response->code($callbackOrStatusCode);
+            $this->response->headers($headers);
         }
 
-        return new JsonResponse($this->createData()->toArray(), $this->response->statusCode(), $headers);
+        return new JsonResponse($this->createData()->toArray(), $this->response->statusCode(), $this->response->getHeaders());
     }
 }

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -8,8 +8,10 @@ use Spatie\Fractalistic\Fractal as Fractalistic;
 
 class Fractal extends Fractalistic
 {
+    /** @var \Spatie\Fractal\Response */
     protected $response;
 
+    /** @param \League\Fractal\Manager $manager */
     public function __construct(Manager $manager)
     {
         parent::__construct($manager);
@@ -17,6 +19,14 @@ class Fractal extends Fractalistic
         $this->response = new Response;
     }
 
+    /**
+     * Return a new JSON response.
+     *
+     * @param  callable|integer $callbackOrStatusCode
+     * @param  array            $headers
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function respond($callbackOrStatusCode = 200, $headers = [])
     {
         if (is_callable($callbackOrStatusCode)) {

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -2,12 +2,28 @@
 
 namespace Spatie\Fractal;
 
+use League\Fractal\Manager;
 use Spatie\Fractalistic\Fractal as Fractalistic;
 
 class Fractal extends Fractalistic
 {
-    public function respond($statusCode = 200, $headers = [])
+    protected $response;
+
+    public function __construct(Manager $manager)
     {
-        return response()->json($this->createData()->toArray(), $statusCode, $headers);
+        parent::__construct($manager);
+
+        $this->response = new Response;
+    }
+
+    public function respond($callbackOrStatusCode = 200, $headers = [])
+    {
+        if (is_callable($callbackOrStatusCode)) {
+            $callbackOrStatusCode($this->response);
+        } else {
+            $this->response->code($callbackOrStatusCode);
+        }
+
+        return response()->json($this->createData()->toArray(), $this->response->statusCode(), $headers);
     }
 }

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -6,8 +6,8 @@ use Spatie\Fractalistic\Fractal as Fractalistic;
 
 class Fractal extends Fractalistic
 {
-    public function respond()
+    public function respond($statusCode = 200)
     {
-        return response()->json($this->createData()->toArray());
+        return response()->json($this->createData()->toArray(), $statusCode);
     }
 }

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Fractal;
 
+use Illuminate\Http\JsonResponse;
 use League\Fractal\Manager;
 use Spatie\Fractalistic\Fractal as Fractalistic;
 
@@ -24,6 +25,6 @@ class Fractal extends Fractalistic
             $this->response->code($callbackOrStatusCode);
         }
 
-        return response()->json($this->createData()->toArray(), $this->response->statusCode(), $headers);
+        return new JsonResponse($this->createData()->toArray(), $this->response->statusCode(), $headers);
     }
 }

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -6,8 +6,8 @@ use Spatie\Fractalistic\Fractal as Fractalistic;
 
 class Fractal extends Fractalistic
 {
-    public function respond($statusCode = 200)
+    public function respond($statusCode = 200, $headers = [])
     {
-        return response()->json($this->createData()->toArray(), $statusCode);
+        return response()->json($this->createData()->toArray(), $statusCode, $headers);
     }
 }

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -6,5 +6,8 @@ use Spatie\Fractalistic\Fractal as Fractalistic;
 
 class Fractal extends Fractalistic
 {
-
+    public function respond()
+    {
+        return response()->json($this->createData()->toArray());
+    }
 }

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Fractal;
 
-use Illuminate\Http\JsonResponse;
 use League\Fractal\Manager;
+use Illuminate\Http\JsonResponse;
 use Spatie\Fractalistic\Fractal as Fractalistic;
 
 class Fractal extends Fractalistic
@@ -22,8 +22,8 @@ class Fractal extends Fractalistic
     /**
      * Return a new JSON response.
      *
-     * @param  callable|integer $callbackOrStatusCode
-     * @param  array            $headers
+     * @param  callable|int $callbackOrStatusCode
+     * @param  array        $headers
      *
      * @return \Illuminate\Http\JsonResponse
      */

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -27,13 +27,18 @@ class Fractal extends Fractalistic
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function respond($callbackOrStatusCode = 200, $headers = [])
+    public function respond($callbackOrStatusCode = 200, $callbackOrHeaders = [])
     {
         if (is_callable($callbackOrStatusCode)) {
             $callbackOrStatusCode($this->response);
         } else {
             $this->response->code($callbackOrStatusCode);
-            $this->response->headers($headers);
+
+            if (is_callable($callbackOrHeaders)) {
+                $callbackOrHeaders($this->response);
+            } else {
+                $this->response->headers($callbackOrHeaders);
+            }
         }
 
         return new JsonResponse($this->createData()->toArray(), $this->response->statusCode(), $this->response->getHeaders());

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\Fractal;
+
+use Spatie\Fractalistic\Fractal as Fractalistic;
+
+class Fractal extends Fractalistic
+{
+
+}

--- a/src/FractalServiceProvider.php
+++ b/src/FractalServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Fractal;
 
-use Spatie\Fractalistic\Fractal;
 use Illuminate\Support\ServiceProvider;
 use League\Fractal\Serializer\SerializerAbstract;
 use Spatie\Fractal\Console\Commands\TransformerMakeCommand;

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Fractal;
+
+class Response
+{
+    protected $statusCode;
+
+    public function statusCode()
+    {
+        return $this->statusCode;
+    }
+
+    public function code($statusCode)
+    {
+        $this->statusCode = $statusCode;
+    }
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -15,6 +15,8 @@ class Response
     public function code($statusCode)
     {
         $this->statusCode = $statusCode;
+
+        return $this;
     }
 
     public function getHeaders()
@@ -25,6 +27,8 @@ class Response
     public function header($key, $value)
     {
         $this->headers[$key] = $value;
+
+        return $this;
     }
 
     public function headers($headers)
@@ -32,5 +36,7 @@ class Response
         foreach ($headers as $key => $value) {
             $this->header($key, $value);
         }
+
+        return $this;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -4,14 +4,29 @@ namespace Spatie\Fractal;
 
 class Response
 {
+    /** @var integer */
     protected $statusCode = 200;
+
+    /** @var array */
     protected $headers = [];
 
+    /**
+     * Get the status code.
+     *
+     * @return int
+     */
     public function statusCode()
     {
         return $this->statusCode;
     }
 
+    /**
+     * Set the status code.
+     *
+     * @param  int $statusCode
+     *
+     * @return self
+     */
     public function code($statusCode)
     {
         $this->statusCode = $statusCode;
@@ -19,11 +34,24 @@ class Response
         return $this;
     }
 
+    /**
+     * Return HTTP headers.
+     *
+     * @return array
+     */
     public function getHeaders()
     {
         return $this->headers;
     }
 
+    /**
+     * Set one HTTP header.
+     *
+     * @param  string $key
+     * @param  string $value
+     *
+     * @return self
+     */
     public function header($key, $value)
     {
         $this->headers[$key] = $value;
@@ -31,6 +59,13 @@ class Response
         return $this;
     }
 
+    /**
+     * Set multiple headers at once.
+     *
+     * @param  array $headers
+     *
+     * @return self
+     */
     public function headers($headers)
     {
         foreach ($headers as $key => $value) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -5,6 +5,7 @@ namespace Spatie\Fractal;
 class Response
 {
     protected $statusCode;
+    protected $headers = [];
 
     public function statusCode()
     {
@@ -14,5 +15,22 @@ class Response
     public function code($statusCode)
     {
         $this->statusCode = $statusCode;
+    }
+
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    public function header($key, $value)
+    {
+        $this->headers[$key] = $value;
+    }
+
+    public function headers($headers)
+    {
+        foreach ($headers as $key => $value) {
+            $this->header($key, $value);
+        }
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -4,7 +4,7 @@ namespace Spatie\Fractal;
 
 class Response
 {
-    protected $statusCode;
+    protected $statusCode = 200;
     protected $headers = [];
 
     public function statusCode()

--- a/src/Response.php
+++ b/src/Response.php
@@ -4,7 +4,7 @@ namespace Spatie\Fractal;
 
 class Response
 {
-    /** @var integer */
+    /** @var int */
     protected $statusCode = 200;
 
     /** @var array */

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-use Spatie\Fractalistic\Fractal;
+use Spatie\Fractal\Fractal;
 use League\Fractal\Serializer\SerializerAbstract;
 
 if (! function_exists('fractal')) {
@@ -9,7 +9,7 @@ if (! function_exists('fractal')) {
      * @param null|callable|\League\Fractal\TransformerAbstract $transformer
      * @param null|\League\Fractal\Serializer\SerializerAbstract $serializer
      *
-     * @return \Spatie\Fractalistic\Fractal
+     * @return \Spatie\Fractal\Fractal
      */
     function fractal($data = null, $transformer = null, $serializer = null)
     {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -7,5 +7,16 @@ use Spatie\Fractal\Fractal;
 
 class ResponseTest extends TestCase
 {
-    //
+    /** @test */
+    public function it_makes_a_json_response() {
+        $response = fractal()
+            ->collection(['item', 'item2'])
+            ->transformWith(function ($item) {
+                return $item.'-transformed';
+            })
+            ->respond();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals('{"data":["item-transformed","item2-transformed"]}', json_encode($response->getData()));
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -7,14 +7,18 @@ use Spatie\Fractal\Fractal;
 
 class ResponseTest extends TestCase
 {
-    /** @test */
-    public function it_makes_a_json_response() {
-        $response = fractal()
+    public function fractal()
+    {
+        return fractal()
             ->collection(['item', 'item2'])
             ->transformWith(function ($item) {
                 return $item.'-transformed';
-            })
-            ->respond();
+            });
+    }
+
+    /** @test */
+    public function it_makes_a_json_response() {
+        $response = $this->fractal()->respond();
 
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals('{"data":["item-transformed","item2-transformed"]}', json_encode($response->getData()));
@@ -23,23 +27,14 @@ class ResponseTest extends TestCase
 
     /** @test */
     public function it_sets_a_status_code_provided_as_a_parameter() {
-        $response = fractal()
-            ->collection(['item', 'item2'])
-            ->transformWith(function ($item) {
-                return $item.'-transformed';
-            })
-            ->respond(404);
+        $response = $this->fractal()->respond(404);
 
         $this->assertEquals(404, $response->status());
     }
 
     /** @test */
     public function it_sets_headers_provided_as_a_parameter() {
-        $response = fractal()
-            ->collection(['item', 'item2'])
-            ->transformWith(function ($item) {
-                return $item.'-transformed';
-            })
+        $response = $this->fractal()
             ->respond(404, ['test' => 'test-value', 'test2' => 'test2-value']);
 
         $this->assertArraySubset([
@@ -50,11 +45,7 @@ class ResponseTest extends TestCase
 
     /** @test */
     public function status_code_can_be_provided_in_the_closure() {
-        $response = fractal()
-            ->collection(['item', 'item2'])
-            ->transformWith(function ($item) {
-                return $item.'-transformed';
-            })
+        $response = $this->fractal()
             ->respond(function ($response) {
                 $response->code(404);
             });
@@ -64,11 +55,7 @@ class ResponseTest extends TestCase
 
     /** @test */
     public function headers_can_be_provided_in_the_closure() {
-        $response = fractal()
-            ->collection(['item', 'item2'])
-            ->transformWith(function ($item) {
-                return $item.'-transformed';
-            })
+        $response = $this->fractal()
             ->respond(function ($response) {
                 $response->header('test', 'test-value');
                 $response->headers(['test2' => 'test2-value']);
@@ -82,11 +69,7 @@ class ResponseTest extends TestCase
 
     /** @test */
     public function callback_allows_chaining() {
-        $response = fractal()
-            ->collection(['item', 'item2'])
-            ->transformWith(function ($item) {
-                return $item.'-transformed';
-            })
+        $response = $this->fractal()
             ->respond(function ($response) {
                 $response
                     ->header('test', 'test-value')

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -71,4 +71,32 @@ class ResponseTest extends TestCase
 
         $this->assertArraySubset(['test' => ['test-value']], $response->headers->all());
     }
+
+    /** @test */
+    public function callback_allows_chaining() {
+        $response = fractal()
+            ->collection(['item', 'item2'])
+            ->transformWith(function ($item) {
+                return $item.'-transformed';
+            })
+            ->respond(function ($response) {
+                $response
+                    ->header('test', 'test-value')
+                    ->code(404)
+                    ->headers([
+                        'test3' => 'test3-value',
+                        'test4' => 'test4-value',
+                    ])
+                    ->header('test2', 'test2-value');
+            });
+
+        $this->assertArraySubset([
+            'test' => ['test-value'],
+            'test2' => ['test2-value'],
+            'test3' => ['test3-value'],
+            'test4' => ['test4-value'],
+        ], $response->headers->all());
+
+        $this->assertEquals(404, $response->status());
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -7,6 +7,7 @@ use Spatie\Fractal\Fractal;
 
 class ResponseTest extends TestCase
 {
+    /** Set-up a new Fractal instance using fractal() helper method */
     public function fractal()
     {
         return fractal()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -71,9 +71,13 @@ class ResponseTest extends TestCase
             })
             ->respond(function ($response) {
                 $response->header('test', 'test-value');
+                $response->headers(['test2' => 'test2-value']);
             });
 
-        $this->assertArraySubset(['test' => ['test-value']], $response->headers->all());
+        $this->assertArraySubset([
+            'test' => ['test-value'],
+            'test2' => ['test2-value'],
+        ], $response->headers->all());
     }
 
     /** @test */

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -74,6 +74,20 @@ class ResponseTest extends TestCase
     }
 
     /** @test */
+    public function the_code_can_be_allowed_along_with_the_callback()
+    {
+        $response = $this->fractal()
+            ->respond(404, function ($response) {
+                $response->header('test', 'test-value');
+            });
+
+        $this->assertEquals(404, $response->status());
+        $this->assertArraySubset([
+            'test' => ['test-value'],
+        ], $response->headers->all());
+    }
+
+    /** @test */
     public function callback_allows_chaining()
     {
         $response = $this->fractal()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -31,4 +31,23 @@ class ResponseTest extends TestCase
 
         $this->assertEquals(404, $response->status());
     }
+
+    /** @test */
+    public function it_sets_headers_provided_as_a_parameter() {
+        $response = fractal()
+            ->collection(['item', 'item2'])
+            ->transformWith(function ($item) {
+                return $item.'-transformed';
+            })
+            ->respond(404, ['test' => 'test-value']);
+
+        $found = false;
+        foreach ($response->headers->all() as $key => $value) {
+            if ($key === 'test' && $value[0] === 'test-value') {
+                $found = true;
+            }
+        }
+
+        $this->assertTrue($found);
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -64,4 +64,18 @@ class ResponseTest extends TestCase
 
         $this->assertEquals(404, $response->status());
     }
+
+    /** @test */
+    public function headers_can_be_provided_in_the_closure() {
+        $response = fractal()
+            ->collection(['item', 'item2'])
+            ->transformWith(function ($item) {
+                return $item.'-transformed';
+            })
+            ->respond(function ($response) {
+                $response->header('test', 'test-value');
+            });
+
+        $this->assertArraySubset(['test' => ['test-value']], $response->headers->all());
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Fractal\Test;
 
-use Illuminate\Http\JsonResponse;
 use Spatie\Fractal\Fractal;
+use Illuminate\Http\JsonResponse;
 
 class ResponseTest extends TestCase
 {
@@ -18,7 +18,8 @@ class ResponseTest extends TestCase
     }
 
     /** @test */
-    public function it_makes_a_json_response() {
+    public function it_makes_a_json_response()
+    {
         $response = $this->fractal()->respond();
 
         $this->assertInstanceOf(JsonResponse::class, $response);
@@ -27,14 +28,16 @@ class ResponseTest extends TestCase
     }
 
     /** @test */
-    public function it_sets_a_status_code_provided_as_a_parameter() {
+    public function it_sets_a_status_code_provided_as_a_parameter()
+    {
         $response = $this->fractal()->respond(404);
 
         $this->assertEquals(404, $response->status());
     }
 
     /** @test */
-    public function it_sets_headers_provided_as_a_parameter() {
+    public function it_sets_headers_provided_as_a_parameter()
+    {
         $response = $this->fractal()
             ->respond(404, ['test' => 'test-value', 'test2' => 'test2-value']);
 
@@ -45,7 +48,8 @@ class ResponseTest extends TestCase
     }
 
     /** @test */
-    public function status_code_can_be_provided_in_the_closure() {
+    public function status_code_can_be_provided_in_the_closure()
+    {
         $response = $this->fractal()
             ->respond(function ($response) {
                 $response->code(404);
@@ -55,7 +59,8 @@ class ResponseTest extends TestCase
     }
 
     /** @test */
-    public function headers_can_be_provided_in_the_closure() {
+    public function headers_can_be_provided_in_the_closure()
+    {
         $response = $this->fractal()
             ->respond(function ($response) {
                 $response->header('test', 'test-value');
@@ -69,7 +74,8 @@ class ResponseTest extends TestCase
     }
 
     /** @test */
-    public function callback_allows_chaining() {
+    public function callback_allows_chaining()
+    {
         $response = $this->fractal()
             ->respond(function ($response) {
                 $response

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -39,9 +39,12 @@ class ResponseTest extends TestCase
             ->transformWith(function ($item) {
                 return $item.'-transformed';
             })
-            ->respond(404, ['test' => 'test-value']);
+            ->respond(404, ['test' => 'test-value', 'test2' => 'test2-value']);
 
-        $this->assertArraySubset(['test' => ['test-value']], $response->headers->all());
+        $this->assertArraySubset([
+            'test' => ['test-value'],
+            'test2' => ['test2-value'],
+        ], $response->headers->all());
     }
 
     /** @test */

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\Fractal\Test;
+
+use Illuminate\Http\JsonResponse;
+use Spatie\Fractal\Fractal;
+
+class ResponseTest extends TestCase
+{
+    //
+}

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -18,6 +18,7 @@ class ResponseTest extends TestCase
 
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals('{"data":["item-transformed","item2-transformed"]}', json_encode($response->getData()));
+        $this->assertEquals(200, $response->status());
     }
 
     /** @test */

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -19,4 +19,16 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals('{"data":["item-transformed","item2-transformed"]}', json_encode($response->getData()));
     }
+
+    /** @test */
+    public function it_sets_a_status_code_provided_as_a_parameter() {
+        $response = fractal()
+            ->collection(['item', 'item2'])
+            ->transformWith(function ($item) {
+                return $item.'-transformed';
+            })
+            ->respond(404);
+
+        $this->assertEquals(404, $response->status());
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -41,14 +41,7 @@ class ResponseTest extends TestCase
             })
             ->respond(404, ['test' => 'test-value']);
 
-        $found = false;
-        foreach ($response->headers->all() as $key => $value) {
-            if ($key === 'test' && $value[0] === 'test-value') {
-                $found = true;
-            }
-        }
-
-        $this->assertTrue($found);
+        $this->assertArraySubset(['test' => ['test-value']], $response->headers->all());
     }
 
     /** @test */

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -50,4 +50,18 @@ class ResponseTest extends TestCase
 
         $this->assertTrue($found);
     }
+
+    /** @test */
+    public function status_code_can_be_provided_in_the_closure() {
+        $response = fractal()
+            ->collection(['item', 'item2'])
+            ->transformWith(function ($item) {
+                return $item.'-transformed';
+            })
+            ->respond(function ($response) {
+                $response->code(404);
+            });
+
+        $this->assertEquals(404, $response->status());
+    }
 }


### PR DESCRIPTION
As per this issue: https://github.com/spatie/fractalistic/issues/7 I am making a PR with proposed changes.

I am open to suggestions :)

---

There may be a benefit in removing the `\Spatie\Fractal\Response` and using the Illuminate Response instead. We could also try to extend Illuminate Response by Fractal Response to preserve Laravel's native API, yet add our own methods.

---

P.S. These have been my first unit tests ever. Please provide some feedback if something is not done 'the right' way.
P.P.S. I am indeed terrible at naming things. Currently, public methods are:
```php
statusCode(); // get a status code
code();       // set a status code
getHeaders(); // get all headers
header();     // set one header
headers();    // set multiple headers
```

I would also suggest adding those aliases: (some of them ofc)
```php
// adding status code
responseCode();
withStatusCode();
withCode();
addCode();
setCode();
setStatusCode();

// adding header/s
setHeader();
addHeader();
withHeader();

setHeaders();
addHeaders();
withHeaders();
```