### PR TITLE
Added closure support for default serializer to config file

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -20,7 +20,7 @@ if (! function_exists('fractal')) {
         if (! empty($serializer)) {
             if ($serializer instanceof SerializerAbstract) {
                 $fractal->serializeWith($serializer);
-            } else if ($serializer instanceof Closure) {
+            } elseif ($serializer instanceof Closure) {
                 $fractal->serializeWith($serializer());
             } else {
                 $fractal->serializeWith(new $serializer());

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -20,6 +20,8 @@ if (! function_exists('fractal')) {
         if (! empty($serializer)) {
             if ($serializer instanceof SerializerAbstract) {
                 $fractal->serializeWith($serializer);
+            } else if ($serializer instanceof Closure) {
+                $fractal->serializeWith($serializer());
             } else {
                 $fractal->serializeWith(new $serializer());
             }

--- a/tests/ClosureDefaultSerializerTest.php
+++ b/tests/ClosureDefaultSerializerTest.php
@@ -6,7 +6,6 @@ use Spatie\Fractalistic\ArraySerializer;
 
 class ClosureDefaultSerializerTest extends TestCase
 {
-
     public function setUp($defaultSerializer = '')
     {
         parent::setup(function () {
@@ -26,5 +25,4 @@ class ClosureDefaultSerializerTest extends TestCase
 
         $this->assertEquals($expectedArray, $array);
     }
-
 }

--- a/tests/ClosureDefaultSerializerTest.php
+++ b/tests/ClosureDefaultSerializerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Fractal\Test;
+
+use Spatie\Fractalistic\ArraySerializer;
+
+class ClosureDefaultSerializerTest extends TestCase
+{
+
+    public function setUp($defaultSerializer = '')
+    {
+        parent::setup(function() {
+            return new ArraySerializer();
+        });
+    }
+
+    /** @test */
+    public function it_uses_the_default_transformer_when_it_is_specified()
+    {
+        $array = $this->fractal
+            ->item($this->testBooks[0])
+            ->transformWith(new TestTransformer())
+            ->toArray();
+
+        $expectedArray = ['id' => 1, 'author' => 'Philip K Dick'];
+
+        $this->assertEquals($expectedArray, $array);
+    }
+
+}

--- a/tests/ClosureDefaultSerializerTest.php
+++ b/tests/ClosureDefaultSerializerTest.php
@@ -9,7 +9,7 @@ class ClosureDefaultSerializerTest extends TestCase
 
     public function setUp($defaultSerializer = '')
     {
-        parent::setup(function() {
+        parent::setup(function () {
             return new ArraySerializer();
         });
     }


### PR DESCRIPTION
If you want to use Serializers that require a url parameter, like the JsonApiSerializer, you were not able to set the default serializer in the `laravel-fractal.php` config file like this and continue to use the artisan command line tool:

```php
return [
    'default_serializer' => new \League\Fractal\Serializer\JsonApiSerializer(url('/')),
];
```

This is due to the fact that in the FractalServiceProvider this config file is read on every boot of Laravel and the failing of the url function outside of a web request (which is quite obvious).
To resolve this issue, one had to resort to setting this in the base Controller class or somewhere else, although there is a place designated to setting a default serializer.

This pull requests introduces the option to use a closure to pass the default serializer like this:

```php
return [
    'default_serializer' => function () {
        return new \League\Fractal\Serializer\JsonApiSerializer(url('/'));
    },
];
```

The closure is only evaluated when the fractal() function is called the first time. This should only be the case on a web request.

I'm not to confident in the provided test as I'm not used to testing and would be happy to implement any other tests, if asked for.

Fixes #28.