### PR TITLE
Don't reimplement existing functionality

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -13,11 +13,9 @@ class Response extends JsonResponse
      *
      * @return self
      */
-    public function headers($headers)
+    public function headers(array $headers)
     {
-        foreach ($headers as $key => $value) {
-            $this->header($key, $value);
-        }
+        $this->withHeaders($headers);
 
         return $this;
     }


### PR DESCRIPTION
1. Removed provided functionality and used a provided by Laravel one instead. (since now the `Request` object extends `Illuminate\Http\JsonResponse` that uses an `Illuminate\Http\ResponseTrait`)
2. Added an `array` typehint.