### PR TITLE
Fix custom-config for Fractal instantiated from DI container

### DIFF
--- a/src/FractalServiceProvider.php
+++ b/src/FractalServiceProvider.php
@@ -33,5 +33,7 @@ class FractalServiceProvider extends ServiceProvider
         $this->app->bind('laravel-fractal', function (...$arguments) {
             return fractal(...$arguments);
         });
+        
+        $this->app->alias('laravel-fractal', Fractal::class);
     }
 }

--- a/tests/FractalInstanceTest.php
+++ b/tests/FractalInstanceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\Fractal\Test;
+
+use Spatie\Fractalistic\ArraySerializer;
+use Spatie\Fractal\Fractal;
+
+class FractalInstanceTest extends TestCase
+{
+    public function setUp($defaultSerializer = '')
+    {
+        parent::setup(ArraySerializer::class);
+
+        $this->fractal = $this->app->make(Fractal::class);
+    }
+    /** @test */
+    public function it_returns_an_instance_of_fractal_when_using_app_make()
+    {
+        $this->assertInstanceOf(Fractal::class, $this->app->make(Fractal::class));
+    }
+
+    /** @test */
+    public function it_uses_the_default_serializer_when_it_is_specified()
+    {
+        $array = $this->fractal
+            ->item($this->testBooks[0])
+            ->transformWith(new TestTransformer())
+            ->toArray();
+
+        $expectedArray = ['id' => 1, 'author' => 'Philip K Dick'];
+        
+        $this->assertEquals($expectedArray, $array);
+    }
+}


### PR DESCRIPTION
I couldn't use Fractal instance from container, because it was ignoring my custom-config(default_serializer). Until last update i did, everything worked fine. This PR fix the issue. I wrote test so you can check how its behaves with and without alias.