### PR TITLE
Add baseUrl support for JsonApi serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ return [
     */
 
     'default_serializer' => '',
+    
+    /*
+    |--------------------------------------------------------------------------
+    | JsonApiSerializer links support
+    |--------------------------------------------------------------------------
+    |
+    | Enables links support for League\Fractal\Serializer\JsonApiSerializer.
+    | It automatically generates links for transformable entities.
+    |
+    */
+    'base_url' => null,
 
 ];
 ```

--- a/resources/config/laravel-fractal.php
+++ b/resources/config/laravel-fractal.php
@@ -15,6 +15,15 @@ return [
 
     'default_serializer' => '',
 
+    /*
+    |--------------------------------------------------------------------------
+    | JsonApiSerializer links support
+    |--------------------------------------------------------------------------
+    |
+    | Enables links support for League\Fractal\Serializer\JsonApiSerializer.
+    | It automatically generates links for transformable entities.
+    |
+    */
     'base_url' => null,
 
 ];

--- a/resources/config/laravel-fractal.php
+++ b/resources/config/laravel-fractal.php
@@ -15,4 +15,6 @@ return [
 
     'default_serializer' => '',
 
+    'base_url' => null,
+
 ];

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -5,6 +5,7 @@ namespace Spatie\Fractal;
 use Closure;
 use League\Fractal\Manager;
 use Illuminate\Http\JsonResponse;
+use League\Fractal\Serializer\JsonApiSerializer;
 use Spatie\Fractalistic\Fractal as Fractalistic;
 use League\Fractal\Serializer\SerializerAbstract;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -47,6 +48,12 @@ class Fractal extends Fractalistic
 
         if ($serializer instanceof Closure) {
             return $fractal->serializeWith($serializer());
+        }
+
+        if ($serializer instanceof JsonApiSerializer) {
+            $baseUrl = config('laravel-fractal.base_url');
+
+            return $fractal->serializeWith(new $serializer($baseUrl));
         }
 
         return $fractal->serializeWith(new $serializer());

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -50,13 +50,13 @@ class Fractal extends Fractalistic
             return $fractal->serializeWith($serializer());
         }
 
-        if ($serializer instanceof JsonApiSerializer) {
+        if ($serializer == 'League\Fractal\Serializer\JsonApiSerializer') {
             $baseUrl = config('laravel-fractal.base_url');
 
             return $fractal->serializeWith(new $serializer($baseUrl));
         }
 
-        return $fractal->serializeWith(new $serializer());
+        return $fractal->serializeWith(new $serializer);
     }
 
     /**

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -50,7 +50,7 @@ class Fractal extends Fractalistic
             return $fractal->serializeWith($serializer());
         }
 
-        if ($serializer == 'League\Fractal\Serializer\JsonApiSerializer') {
+        if ($serializer == JsonApiSerializer::class) {
             $baseUrl = config('laravel-fractal.base_url');
 
             return $fractal->serializeWith(new $serializer($baseUrl));

--- a/tests/JsonApiSerializerTest.php
+++ b/tests/JsonApiSerializerTest.php
@@ -14,6 +14,64 @@ class JsonApiSerializerTest extends TestCase
     }
 
     /** @test */
+    public function it_cannot_has_links_when_json_api_base_url_is_null_on_instantiate()
+    {
+        app('config')->set('laravel-fractal.base_url', null);
+
+        $fractal = fractal()
+            ->collection([
+                [
+                    'id' => 1,
+                    'title' => 'Test 1',
+                ],
+                [
+                    'id' => 4,
+                    'title' => 'Test 2',
+                ],
+            ])
+            ->transformWith(function ($item) {
+                return [
+                    'id' => $item['id'],
+                    'title' => $item['title'].'-transformed',
+                ];
+            })
+            ->withResourceName('articles')
+            ->respond();
+
+        $this->assertObjectNotHasAttribute('links', $fractal->getData()->data[0]);
+        $this->assertObjectNotHasAttribute('links', $fractal->getData()->data[1]);
+    }
+
+    /** @test */
+    public function it_can_has_relative_links_when_json_api_has_empty_string_base_url_on_instantiate()
+    {
+        app('config')->set('laravel-fractal.base_url', '');
+
+        $fractal = fractal()
+            ->collection([
+                [
+                    'id' => 1,
+                    'title' => 'Test 1',
+                ],
+                [
+                    'id' => 4,
+                    'title' => 'Test 2',
+                ],
+            ])
+            ->transformWith(function ($item) {
+                return [
+                    'id' => $item['id'],
+                    'title' => $item['title'].'-transformed',
+                ];
+            })
+            ->withResourceName('articles')
+            ->respond();
+
+        $this->assertEquals('/articles/1', $fractal->getData()->data[0]->links->self);
+        $this->assertEquals('/articles/4', $fractal->getData()->data[1]->links->self);
+    }
+
+    /** @test */
     public function it_can_has_links_when_json_api_has_base_url_on_instantiate()
     {
         app('config')->set('laravel-fractal.base_url', 'http://example.com');

--- a/tests/JsonApiSerializerTest.php
+++ b/tests/JsonApiSerializerTest.php
@@ -14,7 +14,7 @@ class JsonApiSerializerTest extends TestCase
     }
 
     /** @test */
-    public function it_cannot_has_links_when_json_api_base_url_is_null_on_instantiate()
+    public function it_will_not_generate_links_when_the_base_url_is_null()
     {
         app('config')->set('laravel-fractal.base_url', null);
 
@@ -43,7 +43,7 @@ class JsonApiSerializerTest extends TestCase
     }
 
     /** @test */
-    public function it_can_has_relative_links_when_json_api_has_empty_string_base_url_on_instantiate()
+    public function it_will_generate_relative_links_when_json_api_has_empty_string_base_url()
     {
         app('config')->set('laravel-fractal.base_url', '');
 
@@ -72,7 +72,7 @@ class JsonApiSerializerTest extends TestCase
     }
 
     /** @test */
-    public function it_can_has_links_when_json_api_has_base_url_on_instantiate()
+    public function it_will_generate_fully_qualified_links_when_json_api_has_base_url()
     {
         app('config')->set('laravel-fractal.base_url', 'http://example.com');
 

--- a/tests/JsonApiSerializerTest.php
+++ b/tests/JsonApiSerializerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\Fractal\Test;
+
+use League\Fractal\Serializer\JsonApiSerializer;
+
+class JsonApiSerializerTest extends TestCase
+{
+    public function setUp($defaultSerializer = '')
+    {
+        parent::setUp();
+
+        app('config')->set('laravel-fractal.default_serializer', JsonApiSerializer::class);
+    }
+
+    /** @test */
+    public function it_can_has_links_when_json_api_has_base_url_on_instantiate()
+    {
+        app('config')->set('laravel-fractal.base_url', 'http://example.com');
+
+        $fractal = fractal()
+            ->collection([
+                [
+                    'id' => 1,
+                    'title' => 'Test 1',
+                ],
+                [
+                    'id' => 4,
+                    'title' => 'Test 2',
+                ],
+            ])
+            ->transformWith(function ($item) {
+                return [
+                    'id' => $item['id'],
+                    'title' => $item['title'] . '-transformed',
+                ];
+            })
+            ->withResourceName('articles')
+            ->respond();
+
+        $this->assertEquals('http://example.com/articles/1', $fractal->getData()->data[0]->links->self);
+        $this->assertEquals('http://example.com/articles/4', $fractal->getData()->data[1]->links->self);
+    }
+}

--- a/tests/JsonApiSerializerTest.php
+++ b/tests/JsonApiSerializerTest.php
@@ -32,7 +32,7 @@ class JsonApiSerializerTest extends TestCase
             ->transformWith(function ($item) {
                 return [
                     'id' => $item['id'],
-                    'title' => $item['title'] . '-transformed',
+                    'title' => $item['title'].'-transformed',
                 ];
             })
             ->withResourceName('articles')


### PR DESCRIPTION
If you want to enable links support for `\League\Fractal\Serializer\JsonApiSerializer`, just set a `base_url` in your config.

Related to #105 