### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     ],
     "require": {
         "php": "^5.6|^7.0",
-        "illuminate/contracts": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/contracts": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
         "spatie/fractalistic": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.2.0|3.3.0|~3.4.0|~3.5.x-dev",
+        "orchestra/testbench": "~3.2.0|3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -60,3 +60,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         }
     ],
     "require": {
-        "php" : "^5.6|^7.0",
-        "illuminate/contracts": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "php": "^5.6|^7.0",
+        "illuminate/contracts": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
         "spatie/fractalistic": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.2.0|3.3.0|~3.4.0",
-        "phpunit/phpunit" : "^5.7.5"
+        "orchestra/testbench": "~3.2.0|3.3.0|~3.4.0|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-fractal/phpunit.xml.dist

...........................                                       27 / 27 (100%)

Time: 4.72 seconds, Memory: 12.00MB

OK (27 tests, 34 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments