### PR TITLE
auto includes

### DIFF
--- a/config/fractal.php
+++ b/config/fractal.php
@@ -30,6 +30,11 @@ return [
         /*
          * The name of key in the request to where we should look for the includes to include.
          */
-        'request_key' => 'include',
+        'include_key' => 'include',
+
+        /*
+         * The name of key in the request to where we should look for the excludes to include.
+         */
+        'exclude_key' => 'exclude',
     ]
 ];

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -32,10 +32,16 @@ class Fractal extends Fractalistic
         $fractal = parent::create($data, $transformer, $serializer);
 
         if (config('fractal.auto_includes.enabled')) {
-            $requestKey = config('fractal.auto_includes.request_key');
+            $includeKey = config('fractal.auto_includes.request_key');
 
-            if (request()->query($requestKey)) {
-                $fractal->parseIncludes(explode(',', request()->query($requestKey)));
+            if (request()->query($includeKey)) {
+                $fractal->parseIncludes(request()->query($includeKey));
+            }
+
+            $excludeKey = config('fractal.auto_excludes.request_key');
+
+            if (request()->query($excludeKey)) {
+                $fractal->parseExcludes(request()->query($excludeKey));
             }
         }
 


### PR DESCRIPTION
This PR implements auto includes feature based on parseIncludes() method from the [spatie/fractalistic](https://github.com/spatie/fractalistic) package:
- include includes "/books?include=author,publishers.somethingelse"
- exclude includes "/books?exclude=author,publishers"
- include parametrs "/books?include=comments:limit(5|1):order(created_at|desc)"

[parseIncludes()](https://github.com/spatie/fractalistic/blob/master/tests/IncludesTest.php) and [parseExcludes()](https://github.com/spatie/fractalistic/blob/master/tests/ExcludesTest.php) methods are well tested, no test included.