### PR TITLE
Allow specifying the Fractal class to be used (#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you want to make use of the facade you must install it as well:
 ];
 ```
 
-If you want to [change the default serializer](https://github.com/spatie/fractalistic#changing-the-default-serializer),
+If you want to [change the default serializer](https://github.com/spatie/fractalistic#changing-the-default-serializer), or the default fractal class `Spatie\Fractal\Fractal`
 you must publish the config file:
 
 ```bash
@@ -125,6 +125,17 @@ return [
     |
     */
     'base_url' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fractal Class
+    |--------------------------------------------------------------------------
+    |
+    | If you wish to override or extend the default Spatie\Fractal\Fractal
+    | instance provide the name of the class you want to use.
+    |
+    */
+    'fractal_class' => 'Spatie\Fractal\Fractal',
 
 ];
 ```

--- a/resources/config/laravel-fractal.php
+++ b/resources/config/laravel-fractal.php
@@ -26,4 +26,15 @@ return [
     */
     'base_url' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Fractal Class
+    |--------------------------------------------------------------------------
+    |
+    | If you wish to override or extend the default Spatie\Fractal\Fractal
+    | instance provide the name of the class you want to use.
+    |
+    */
+    'fractal_class' => 'Spatie\Fractal\Fractal',
+
 ];

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,6 +14,7 @@ if (! function_exists('fractal')) {
     {
         $class = config('laravel-fractal.fractal_class');
         $class = empty($class) ? Fractal::class : $class;
+
         return $class::create($data, $transformer, $serializer);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,6 +12,8 @@ if (! function_exists('fractal')) {
      */
     function fractal($data = null, $transformer = null, $serializer = null)
     {
-        return Fractal::create($data, $transformer, $serializer);
+        $class = config('laravel-fractal.fractal_class');
+        $class = empty($class) ? Fractal::class : $class;
+        return $class::create($data, $transformer, $serializer);
     }
 }

--- a/tests/FractalExtensionClass.php
+++ b/tests/FractalExtensionClass.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\Fractal\Test;
+
+use Spatie\Fractal\Fractal;
+
+class FractalExtensionClass extends Fractal
+{
+}

--- a/tests/FractalInstanceTest.php
+++ b/tests/FractalInstanceTest.php
@@ -15,9 +15,19 @@ class FractalInstanceTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_an_configured_instance_when_resolving_fractal_using_the_container()
+    public function it_returns_a_default_instance_when_resolving_fractal_using_the_container()
     {
         $this->assertInstanceOf(Fractal::class, $this->app->make(Fractal::class));
+    }
+        /** @test */
+    public function it_returns_a_configured_instance_when_resolving_fractal_using_the_container()
+    {
+        app('config')->set('laravel-fractal.fractal_class', FractalExtensionClass::class);
+        // Make container forget about the existing Fractal:class singleton instance
+        $this->app->forgetInstance('laravel-fractal');
+        $this->assertInstanceOf(FractalExtensionClass::class, $this->app->make(Fractal::class));
+        // Make sure following tests use the default Fractal instance
+        $this->app->forgetInstance('laravel-fractal');
     }
 
     /** @test */

--- a/tests/FractalInstanceTest.php
+++ b/tests/FractalInstanceTest.php
@@ -19,7 +19,8 @@ class FractalInstanceTest extends TestCase
     {
         $this->assertInstanceOf(Fractal::class, $this->app->make(Fractal::class));
     }
-        /** @test */
+
+    /** @test */
     public function it_returns_a_configured_instance_when_resolving_fractal_using_the_container()
     {
         app('config')->set('laravel-fractal.fractal_class', FractalExtensionClass::class);


### PR DESCRIPTION
As proposed in #129 ;)
The default value of `fractal_class` is `Spatie\Fractal\Fractal` but if you prefer to have it set to `null` the code will keep working using the default `Spatie\Fractal\Fractal` class

PS: sorry for the horrible commit message