### PR TITLE
Lumen 5.5 compatibility

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -34,8 +34,8 @@ class Fractal extends Fractalistic
         if (config('fractal.auto_includes.enabled')) {
             $requestKey = config('fractal.auto_includes.request_key');
 
-            if (request()->query($requestKey)) {
-                $fractal->parseIncludes(explode(',', request()->query($requestKey)));
+            if (app('request')->query($requestKey)) {
+                $fractal->parseIncludes(explode(',', app('request')->query($requestKey)));
             }
         }
 


### PR DESCRIPTION
Since lumen doesn't have the request global helper like Laravel, i propose we use the underlying functionality for support on both frameworks. #149 