### PR TITLE
Laravel collection macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ There's also a very short syntax available to quickly transform data:
 fractal($books, new BookTransformer())->toArray();
 ```
 
+You can transform directly from a Laravel collection as well:
+
+```php
+collect($books)->transformWith(new BookTransformer());
+```
+
+Transforming right from a Laravel collection is particularly useful for Eloquent results:
+
+```php
+Users::all()->transformWith(new UserTransformer())->toArray();
+```
+
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all
 our open source projects [on our website](https://spatie.be/opensource).
 
@@ -73,7 +85,7 @@ composer require spatie/laravel-fractal
 
 The package will automatically register itself.
 
-If you want to [change the default serializer](https://github.com/spatie/fractalistic#changing-the-default-serializer), 
+If you want to [change the default serializer](https://github.com/spatie/fractalistic#changing-the-default-serializer),
 the [default paginator](https://github.com/spatie/fractalistic#using-pagination),
 or the default fractal class `Spatie\Fractal\Fractal`
 you must publish the config file:
@@ -236,7 +248,7 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/src/FractalServiceProvider.php
+++ b/src/FractalServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
 use Spatie\Fractal\Console\Commands\TransformerMakeCommand;
 use Illuminate\Foundation\Application as LaravelApplication;
+use Illuminate\Support\Collection;
 
 class FractalServiceProvider extends ServiceProvider
 {
@@ -21,6 +22,8 @@ class FractalServiceProvider extends ServiceProvider
                 TransformerMakeCommand::class,
             ]);
         }
+
+        $this->setupMacro();
     }
 
     /**
@@ -46,5 +49,15 @@ class FractalServiceProvider extends ServiceProvider
         }
 
         $this->mergeConfigFrom($source, 'fractal');
+    }
+
+    /**
+     * Add a 'transformWith' macro to Laravel's Collection
+     */
+    protected function setupMacro()
+    {
+        Collection::macro('transformWith', function($transformer) {
+            return fractal($this, $transformer);
+        });
     }
 }

--- a/src/FractalServiceProvider.php
+++ b/src/FractalServiceProvider.php
@@ -2,11 +2,11 @@
 
 namespace Spatie\Fractal;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
 use Spatie\Fractal\Console\Commands\TransformerMakeCommand;
 use Illuminate\Foundation\Application as LaravelApplication;
-use Illuminate\Support\Collection;
 
 class FractalServiceProvider extends ServiceProvider
 {
@@ -52,11 +52,11 @@ class FractalServiceProvider extends ServiceProvider
     }
 
     /**
-     * Add a 'transformWith' macro to Laravel's Collection
+     * Add a 'transformWith' macro to Laravel's collection.
      */
     protected function setupMacro()
     {
-        Collection::macro('transformWith', function($transformer) {
+        Collection::macro('transformWith', function ($transformer) {
             return fractal($this, $transformer);
         });
     }

--- a/tests/LaravelCollectionMacroTest.php
+++ b/tests/LaravelCollectionMacroTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Fractal\Test;
+
+use Spatie\Fractalistic\Fractal;
+use Spatie\Fractalistic\ArraySerializer;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+class LaravelCollectionMacroTest extends TestCase
+{
+    /** @test */
+    public function it_provides_laravel_colletion_macro()
+    {
+        $transformedData = Collection::make($this->testBooks)
+            ->transformWith(new TestTransformer())
+            ->toArray();
+
+        $expectedArray = ['data' => [
+            ['id' => 1, 'author' => 'Philip K Dick'],
+            ['id' => 2, 'author' => 'George R. R. Satan'],
+        ]];
+
+        $this->assertEquals($expectedArray, $transformedData);
+    }
+}

--- a/tests/LaravelCollectionMacroTest.php
+++ b/tests/LaravelCollectionMacroTest.php
@@ -2,9 +2,6 @@
 
 namespace Spatie\Fractal\Test;
 
-use Spatie\Fractalistic\Fractal;
-use Spatie\Fractalistic\ArraySerializer;
-use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 
 class LaravelCollectionMacroTest extends TestCase


### PR DESCRIPTION
This adds a `transformWith` macro to `Illuminate\Support\Collection`. I really like being able to transform directly from an existing collection, particularly for Eloquent results:

```php
Users::all()->transformWith(new UserTransformer())->toArray();
```

Test and docs included.