### PR TITLE
Extend TransformerAbstract class to easily include relations in transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,33 @@ return fractal($books, new BookTransformer())->respond(function(JsonResponse $re
 
 You can run the `make:transformer` command to quickly generate a dummy transformer. By default it will be stored in the `app\Transformers` directory.
 
+## Including relationships in the transformer
+
+To easily add your Eloquent relations to the list of available includes, you may extend `Spatie\Fractal\TransformerAbstract` and add to the arrays `$itemIncludes` and `$collectionIncludes`.
+
+For example, given a model `Article` that has the relations `author` and `comments`:
+
+```php
+class ArticleTransformer extends Spatie\Fractal\TransformerAbstract
+{
+    protected $itemIncludes = [
+        'author' => AuthorTransformer::class,
+    ];
+    
+    protected $collectionIncludes = [
+        'comments' => CommentTransformer::class,
+    ];
+    
+    public function transform(Article $article)
+    {
+        //
+    }
+}
+``` 
+
+This makes available the methods `includeAuthor()` and `includeComments()` on the transformer class.
+
+
 ## Upgrading
 
 ## From v4 to v5

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Fractal;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
@@ -13,12 +12,16 @@ abstract class TransformerAbstract extends FractalTransformer
     /**
      * @var array
      */
-    protected $itemIncludes = [];
+    protected $itemIncludes = [
+        // 'foo' => FooTransformer::class
+    ];
 
     /**
      * @var array
      */
-    protected $collectionIncludes = [];
+    protected $collectionIncludes = [
+        // 'bar' => BarTransformer::class
+    ];
 
     /**
      * TransformerAbstract constructor.
@@ -31,7 +34,7 @@ abstract class TransformerAbstract extends FractalTransformer
     }
 
     /**
-     * Simulate 'includeResource()' methods.
+     * Simulate 'include{$resource}()' methods.
      *
      * @param string $method
      * @param array  $arguments

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Spatie\Fractal;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use League\Fractal\TransformerAbstract as FractalTransformer;
+
+abstract class TransformerAbstract extends FractalTransformer
+{
+    /**
+     * @var array
+     */
+    protected $itemIncludes = [];
+
+    /**
+     * @var array
+     */
+    protected $collectionIncludes = [];
+
+    /**
+     * TransformerAbstract constructor.
+     */
+    public function __construct()
+    {
+        $this->availableIncludes = array_merge($this->availableIncludes,
+            array_keys($this->itemIncludes),
+            array_keys($this->collectionIncludes));
+    }
+
+    /**
+     * Simulate 'includeResource()' methods.
+     *
+     * @param string $method
+     * @param array  $arguments
+     * @return Collection|Item
+     */
+    public function __call($method, $arguments)
+    {
+        $baseResource = $arguments[0] ?? null;
+        $relatedResource = Str::snake(preg_replace('/^include/', '', $method));
+
+        if (array_key_exists($relatedResource, $this->itemIncludes)) {
+            return $this->item($baseResource->{$relatedResource}, new $this->itemIncludes[$relatedResource]);
+        }
+
+        if (array_key_exists($relatedResource, $this->collectionIncludes)) {
+            return $this->collection(
+                $baseResource->{$relatedResource}, new $this->collectionIncludes[$relatedResource]);
+        }
+
+        throw new \BadMethodCallException('Unknown method "' . $method . '" called on ' . static::class . '.');
+    }
+}

--- a/src/TransformerAbstract.php
+++ b/src/TransformerAbstract.php
@@ -3,8 +3,8 @@
 namespace Spatie\Fractal;
 
 use Illuminate\Support\Str;
-use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\Collection;
 use League\Fractal\TransformerAbstract as FractalTransformer;
 
 abstract class TransformerAbstract extends FractalTransformer
@@ -54,6 +54,6 @@ abstract class TransformerAbstract extends FractalTransformer
                 $baseResource->{$relatedResource}, new $this->collectionIncludes[$relatedResource]);
         }
 
-        throw new \BadMethodCallException('Unknown method "' . $method . '" called on ' . static::class . '.');
+        throw new \BadMethodCallException('Unknown method "'.$method.'" called on '.static::class.'.');
     }
 }

--- a/tests/TransformerAbstractTest.php
+++ b/tests/TransformerAbstractTest.php
@@ -32,7 +32,7 @@ class TransformerAbstractTest extends TestCase
     {
         $collection = (new BookTransformer)->includeMainCharacters(new Book);
 
-        $expectedCollection = new Collection((new Book)->main_characters, new mainCharacterTransformer);
+        $expectedCollection = new Collection((new Book)->main_characters, new MainCharacterTransformer);
 
         $this->assertEquals($expectedCollection, $collection);
     }
@@ -93,7 +93,7 @@ class BookTransformer extends TransformerAbstract
 {
     protected $itemIncludes = ['author' => AuthorTransformer::class];
 
-    protected $collectionIncludes = ['main_characters' => mainCharacterTransformer::class];
+    protected $collectionIncludes = ['main_characters' => MainCharacterTransformer::class];
 
     protected $availableIncludes = ['words'];
 
@@ -103,7 +103,7 @@ class BookTransformer extends TransformerAbstract
     }
 }
 
-class mainCharacterTransformer extends TransformerAbstract
+class MainCharacterTransformer extends TransformerAbstract
 {
     public function transform($resource)
     {

--- a/tests/TransformerAbstractTest.php
+++ b/tests/TransformerAbstractTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Spatie\Fractal\Test;
+
+use League\Fractal\Manager;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use Spatie\Fractal\TransformerAbstract;
+
+class TransformerAbstractTest extends TestCase
+{
+    /** @test */
+    public function it_combines_item_and_collection_includes_attributes_into_available_includes()
+    {
+        $transformer = new BookTransformer;
+
+        $this->assertEquals(['words', 'author', 'main_characters'], $transformer->getAvailableIncludes());
+    }
+
+    /** @test */
+    public function it_returns_an_item_for_an_item_relation()
+    {
+        $item = (new BookTransformer)->includeAuthor(new Book);
+
+        $expectedItem = new Item((new Book)->author, new AuthorTransformer());
+
+        $this->assertEquals($expectedItem, $item);
+    }
+
+    /** @test */
+    public function it_returns_a_collection_for_a_collection_relation()
+    {
+        $collection = (new BookTransformer)->includeMainCharacters(new Book);
+
+        $expectedCollection = new Collection((new Book)->main_characters, new mainCharacterTransformer);
+
+        $this->assertEquals($expectedCollection, $collection);
+    }
+
+    /** @test */
+    public function it_throws_a_bad_method_exception_if_a_nonexistent_method_is_called()
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        (new BookTransformer)->badMethod();
+    }
+
+    /** @test */
+    public function it_includes_an_item_resource()
+    {
+        $books = [new Book, new Book];
+
+        $resource = new Collection($books, new BookTransformer);
+        $output = (new Manager)
+            ->parseIncludes('author,main_characters')
+            ->createData($resource)
+            ->toArray();
+
+        $expected = [
+            'data' => [
+                [
+                    "field"           => "Transformed book",
+                    'author'          => [
+                        'data' => ["field" => "Transformed author"]
+                    ],
+                    "main_characters" => [
+                        "data" => [
+                            ["field" => "Transformed character"],
+                            ["field" => "Transformed character"],
+                        ]
+                    ]
+                ],
+                [
+                    "field"           => "Transformed book",
+                    'author'          => [
+                        'data' => ["field" => "Transformed author"]
+                    ],
+                    "main_characters" => [
+                        "data" => [
+                            ["field" => "Transformed character"],
+                            ["field" => "Transformed character"],
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals($expected, $output);
+    }
+}
+
+class BookTransformer extends TransformerAbstract
+{
+    protected $itemIncludes = ['author' => AuthorTransformer::class];
+
+    protected $collectionIncludes = ['main_characters' => mainCharacterTransformer::class];
+
+    protected $availableIncludes = ['words'];
+
+    public function transform($resource)
+    {
+        return ['field' => 'Transformed book'];
+    }
+}
+
+class mainCharacterTransformer extends TransformerAbstract
+{
+    public function transform($resource)
+    {
+        return ['field' => 'Transformed character'];
+    }
+}
+
+class AuthorTransformer extends TransformerAbstract
+{
+    public function transform($resource)
+    {
+        return ['field' => 'Transformed author'];
+    }
+}
+
+class Book
+{
+    public $author;
+    public $main_characters;
+
+    public function __construct()
+    {
+        $this->author = new \stdclass;
+        $this->main_characters = [1, 2];
+    }
+}

--- a/tests/TransformerAbstractTest.php
+++ b/tests/TransformerAbstractTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\Fractal\Test;
 
 use League\Fractal\Manager;
-use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
+use League\Fractal\Resource\Collection;
 use Spatie\Fractal\TransformerAbstract;
 
 class TransformerAbstractTest extends TestCase
@@ -59,30 +59,30 @@ class TransformerAbstractTest extends TestCase
         $expected = [
             'data' => [
                 [
-                    "field"           => "Transformed book",
+                    'field'           => 'Transformed book',
                     'author'          => [
-                        'data' => ["field" => "Transformed author"]
+                        'data' => ['field' => 'Transformed author'],
                     ],
-                    "main_characters" => [
-                        "data" => [
-                            ["field" => "Transformed character"],
-                            ["field" => "Transformed character"],
-                        ]
-                    ]
+                    'main_characters' => [
+                        'data' => [
+                            ['field' => 'Transformed character'],
+                            ['field' => 'Transformed character'],
+                        ],
+                    ],
                 ],
                 [
-                    "field"           => "Transformed book",
+                    'field'           => 'Transformed book',
                     'author'          => [
-                        'data' => ["field" => "Transformed author"]
+                        'data' => ['field' => 'Transformed author'],
                     ],
-                    "main_characters" => [
-                        "data" => [
-                            ["field" => "Transformed character"],
-                            ["field" => "Transformed character"],
-                        ]
-                    ]
-                ]
-            ]
+                    'main_characters' => [
+                        'data' => [
+                            ['field' => 'Transformed character'],
+                            ['field' => 'Transformed character'],
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $this->assertEquals($expected, $output);


### PR DESCRIPTION
When building up APIs with fractal I found myself repeating the same code to include relations on my Eloquent models:

```php
// BookTransformer.php

protected $availableIncludes = [
    'author',
    'characters'
];

public function includeAuthor(Book $book) {
     return $this->item($book->author, new AuthorTransformer);
}

public function includeCharacters(Book $book) {
    return $this->collection($book->characters, new CharacterTransformer);
}
```

This PR enables you to express the above code more succinctly as:

```php
// BookTransformer.php

protected $itemIncludes = [
    'author' => AuthorTransformer::class,
];

protected $collectionIncludes = [
    'characters' => CharacterTransformer::class,
];
```

Tests and docs included.