### PR TITLE
Remove explode statement from auto-include parameter interpretation

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -34,8 +34,8 @@ class Fractal extends Fractalistic
         if (config('fractal.auto_includes.enabled')) {
             $requestKey = config('fractal.auto_includes.request_key');
 
-            if (app('request')->query($requestKey)) {
-                $fractal->parseIncludes(explode(',', app('request')->query($requestKey)));
+            if ($include = app('request')->query($requestKey)) {
+                $fractal->parseIncludes($include);
             }
         }
 

--- a/tests/AutoIncludeTest.php
+++ b/tests/AutoIncludeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Spatie\Fractal\Test;
+
+use League\Fractal\Pagination\IlluminatePaginatorAdapter;
+
+class AutoIncludeTest extends TestCase
+{
+    /** @test */
+    public function includes_can_be_passed_as_array()
+    {
+        $response = $this->call('GET', '/auto-includes', [
+            "include" => [
+                'characters',
+                'publisher',
+            ]
+        ]);
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                ['id', 'author', 'characters', 'publisher']
+            ]
+        ]);
+    }
+
+    /** @test */
+    public function includes_can_be_passed_as_string()
+    {
+        $response = $this->call('GET', '/auto-includes', [
+            "include" => 'characters,publisher'
+        ]);
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                ['id', 'author', 'characters', 'publisher']
+            ]
+        ]);
+    }
+
+    /** @test */
+    public function includes_are_missing_when_parameter_is_not_passed()
+    {
+        $response = $this->call('GET', '/auto-includes');
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                ['id', 'author']
+            ]
+        ]);
+
+        foreach ($response->json()['data'] as $book) {
+            $this->assertArrayNotHasKey('characters', $book);
+            $this->assertArrayNotHasKey('pubisher', $book);
+        }
+    }
+}

--- a/tests/AutoIncludeTest.php
+++ b/tests/AutoIncludeTest.php
@@ -2,24 +2,22 @@
 
 namespace Spatie\Fractal\Test;
 
-use League\Fractal\Pagination\IlluminatePaginatorAdapter;
-
 class AutoIncludeTest extends TestCase
 {
     /** @test */
     public function includes_can_be_passed_as_array()
     {
         $response = $this->call('GET', '/auto-includes', [
-            "include" => [
+            'include' => [
                 'characters',
                 'publisher',
-            ]
+            ],
         ]);
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'data' => [
-                ['id', 'author', 'characters', 'publisher']
-            ]
+                ['id', 'author', 'characters', 'publisher'],
+            ],
         ]);
     }
 
@@ -27,13 +25,13 @@ class AutoIncludeTest extends TestCase
     public function includes_can_be_passed_as_string()
     {
         $response = $this->call('GET', '/auto-includes', [
-            "include" => 'characters,publisher'
+            'include' => 'characters,publisher',
         ]);
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'data' => [
-                ['id', 'author', 'characters', 'publisher']
-            ]
+                ['id', 'author', 'characters', 'publisher'],
+            ],
         ]);
     }
 
@@ -44,8 +42,8 @@ class AutoIncludeTest extends TestCase
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'data' => [
-                ['id', 'author']
-            ]
+                ['id', 'author'],
+            ],
         ]);
 
         foreach ($response->json()['data'] as $book) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -79,10 +79,10 @@ abstract class TestCase extends Orchestra
     protected function setupRoutes()
     {
         Route::get('auto-includes', function () {
-            return $this->fractal
-               ->collection($this->testBooks)
-               ->transformWith(TestTransformer::class)
-               ->toArray();
+            return fractal()
+                ->collection($this->testBooks)
+                ->transformWith(TestTransformer::class)
+                ->toArray();
         });
     }
 }


### PR DESCRIPTION
fixes #153

I am new to pull requests and stuff so feel free to correct me if things aren't as they are supposed. 
I added three API tests that check the auto-include feature. I couldn't find something like that in the repository. 
I needed to use a new fractal instance in the route handler of the test route so that the request parameters of the test call could be parsed. 
If the class' fractal instance is used instead (like it originally was), the parameters are parsed before the actual test request comes in, so they are never present.