### PR TITLE
Make Fractal Class Macroable

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ return fractal($books, new BookTransformer())->respond(function(JsonResponse $re
 });
 ```
 
+You can add methods to the Fractal class using Laravel's Macroable trait. Imagine you want to add some stats to the metadata of your request, you can do so without cluttering your code:
+
+```php
+use Spatie\Fractal\Fractal;
+
+Fractal::macro('stats', function ($stats) {
+    // transform the passed stats as necessary here
+    return $this->appendMeta(['stats' => $stats]);
+});
+
+fractal($books, new BookTransformer())->stats(['runtime' => 100])->respond();
+```
+
 ## Quickly creating a transformer
 
 You can run the `make:transformer` command to quickly generate a dummy transformer. By default it will be stored in the `app\Transformers` directory.

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -6,6 +6,7 @@ use Closure;
 use League\Fractal\Manager;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Traits\Macroable;
 use League\Fractal\Serializer\JsonApiSerializer;
 use Spatie\Fractalistic\Fractal as Fractalistic;
 use League\Fractal\Serializer\SerializerAbstract;
@@ -14,6 +15,10 @@ use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 
 class Fractal extends Fractalistic
 {
+    use Macroable {
+        Macroable::__call as macroCall;
+    }
+
     /** @param \League\Fractal\Manager $manager */
     public function __construct(Manager $manager)
     {
@@ -122,5 +127,14 @@ class Fractal extends Fractalistic
         }
 
         return $response;
+    }
+
+    public function __call($name, array $arguments)
+    {
+        if (static::hasMacro($name)) {
+            return $this->macroCall($name, $arguments);
+        }
+
+        return parent::__call($name, $arguments);
     }
 }

--- a/tests/FractalInstanceTest.php
+++ b/tests/FractalInstanceTest.php
@@ -42,4 +42,21 @@ class FractalInstanceTest extends TestCase
 
         $this->assertEquals($expectedArray, $array);
     }
+
+    /** @test */
+    public function it_can_be_extended_via_macros()
+    {
+        Fractal::macro('firstItem', function ($books) {
+            return $this->item($books[0]);
+        });
+
+        $array = $this->fractal
+            ->firstItem($this->testBooks)
+            ->transformWith(new TestTransformer())
+            ->toArray();
+
+        $expectedArray = ['id' => 1, 'author' => 'Philip K Dick'];
+
+        $this->assertEquals($expectedArray, $array);
+    }
 }


### PR DESCRIPTION
This PR lets the Fractal class use the Macroable trait.

Using this trait you can define expressive shortcuts for common transformation settings or implement some reusable snippets, that are available across your application if you are transforming your responses using fractal. You could also use it to limit the inclusion of data to certain environments (only include dev output in the dev environment) by defining an appendInDev-Macro.