### PR TITLE
Connect the code coverage to scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,3 +17,7 @@ checks:
         fix_identation_4spaces: true
         fix_doc_comments: true
 
+tools:
+    external_code_coverage:
+        timeout: 600
+        runs: 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ before_script:
 
 script:
   - vendor/bin/phpunit --testdox --coverage-text --coverage-clover=coverage.clover
+  
+after_script:
+  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # An easy to use Fractal wrapper built for Laravel and Lumen applications
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-fractal.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-fractal)
+[![Code coverage](https://scrutinizer-ci.com/g/spatie/laravel-fractal/badges/coverage.png)](https://scrutinizer-ci.com/g/spatie/laravel-fractal)
 [![Build Status](https://travis-ci.org/spatie/laravel-fractal.svg?branch=master)](https://travis-ci.org/spatie/laravel-fractal)
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/laravel-fractal.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/laravel-fractal)
 [![StyleCI](https://styleci.io/repos/43743138/shield?branch=master)](https://styleci.io/repos/43743138)

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     },
     "require-dev": {
         "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0",
-        "phpunit/phpunit" : "^6.2|^7.0"
+        "phpunit/phpunit": "^6.2|^7.0",
+        "scrutinizer/ocular": "^1.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have configured the code coverage report from scrutinizer and add the badge to the readme file.

It has 4 steps
1. Add scrutinizer/ocular
2. Allow remote code coverage in .scrutinizer.yml
3. Add the after_script to the travis config to send the data to scrutinizer
4. Add the badge to the readme