### PR TITLE
Fixes singleton definition

### DIFF
--- a/src/FractalServiceProvider.php
+++ b/src/FractalServiceProvider.php
@@ -31,7 +31,7 @@ class FractalServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('fractal', function (...$arguments) {
+        $this->app->singleton('fractal', function ($app, $arguments) {
             return fractal(...$arguments);
         });
 


### PR DESCRIPTION
Allows proper use of `make`.

```php
$app->make('fractal', [$collection, new CollectionTransformer]);
```