### PR TITLE
Update version constraints to allow Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     ],
     "require": {
         "php" : "^7.2",
-        "illuminate/contracts": "~5.7.0|~5.8.0",
-        "illuminate/support": "~5.7.0|~5.8.0",
+        "illuminate/contracts": "~5.7.0|~5.8.0|^6.0",
+        "illuminate/support": "~5.7.0|~5.8.0|^6.0",
         "spatie/fractalistic": "^2.5"
     },
     "require-dev": {


### PR DESCRIPTION
### About
This PR will add `^6.0` to the list of compatible versions of Laravel.

By preemtively adding the new version, it will allow us to give this fractalistic package a spin, before the final release of Laravel 6.0.

In the case that you don't feel comfortable merging/tagging this change before the official release, I'll just continue working off of my fork. :relaxed: :v: