### PR TITLE
Fractal config comment alteration

### DIFF
--- a/config/fractal.php
+++ b/config/fractal.php
@@ -15,7 +15,7 @@ return [
     'default_paginator' => '',
 
     /*
-     * League\Fractal\Serializer\JsonApiSerializer will use this value to
+     * League\Fractal\Serializer\JsonApiSerializer will use this value
      * as a prefix for generated links. Set to `null` to disable this.
      */
     'base_url' => null,


### PR DESCRIPTION
Removed the `to` from the `base_url` comment as it's presence made no sense in that sentence.