### PR TITLE
fix: wrong `return` annotation

### DIFF
--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -29,7 +29,7 @@ class Fractal extends Fractalistic
      * @param null|callable|\League\Fractal\TransformerAbstract $transformer
      * @param null|\League\Fractal\Serializer\SerializerAbstract $serializer
      *
-     * @return \Spatie\Fractalistic\Fractal
+     * @return \Spatie\Fractal\Fractal
      */
     public static function create($data = null, $transformer = null, $serializer = null)
     {

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -29,7 +29,7 @@ class Fractal extends Fractalistic
      * @param null|callable|\League\Fractal\TransformerAbstract $transformer
      * @param null|\League\Fractal\Serializer\SerializerAbstract $serializer
      *
-     * @return \Spatie\Fractal\Fractal
+     * @return static
      */
     public static function create($data = null, $transformer = null, $serializer = null)
     {


### PR DESCRIPTION
## Summary
The incorrect annotation is causing confusion in static analysis.
The `create` method actually returns `\Spatie\Fractal\Fractal`, not `\Spatie\Fractalistic\Fractal`. When `Fractal::create` is called, it invokes the parent (Fractalistic) `create` method using `parent::create`. This parent method, in turn, uses the `new static` keyword to return an instance of the subclass when called from that subclass. Therefore, the return type of `Fractal::create` is actually `Fractal`, not `Fractalistic`.
So, by changing the annotated return type to `@return static`, we can easily extend `\Spatie\Fractal\Fractal` and the return type problem will be solved.

## Problem
Consider this example: You've created a macro named `ok` on `Fractal`. However, your IDE complains that the `ok` method doesn't exist on `Fractalistic`. The issue lies in the `@return` annotation, which incorrectly indicates that `create` returns `Fractalistic` instead of `Fractal`. By correcting this annotation, static analyzers will recognize the macro on `Fractal`.

![image](https://github.com/spatie/laravel-fractal/assets/24431504/38cc8560-a025-4a56-bb56-35ced0449af3)