### PR TITLE
Allow auto parsing the `fieldsets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This is the contents of the published file:
 
 ```php
 return [
-     /*
+    /*
      * The default serializer to be used when performing a transformation. It
      * may be left empty to use Fractal's default one. This can either be a
      * string or a League\Fractal\Serializer\SerializerAbstract subclass.
@@ -105,11 +105,12 @@ return [
 
     /* The default paginator to be used when performing a transformation. It
      * may be left empty to use Fractal's default one. This can either be a
-     * string or a League\Fractal\Paginator\PaginatorInterface subclass.*/
+     * string or a League\Fractal\Paginator\PaginatorInterface subclass.
+     */
     'default_paginator' => '',
 
     /*
-     * League\Fractal\Serializer\JsonApiSerializer will use this value to
+     * League\Fractal\Serializer\JsonApiSerializer will use this value
      * as a prefix for generated links. Set to `null` to disable this.
      */
     'base_url' => null,
@@ -133,12 +134,12 @@ return [
          */
         'request_key' => 'include',
     ],
-    
+
     'auto_excludes' => [
 
         /*
          * If enabled Fractal will automatically add the excludes who's
-         * names are present in the `include` request parameter.
+         * names are present in the `exclude` request parameter.
          */
         'enabled' => true,
 
@@ -147,6 +148,21 @@ return [
          */
         'request_key' => 'exclude',
     ],
+
+    'auto_fieldsets' => [
+
+        /*
+         * If enabled Fractal will automatically add the fieldsets who's
+         * names are present in the `fields` request parameter.
+         */
+        'enabled' => true,
+
+        /*
+         * The name of key in the request, where we should look for the fieldsets to parse.
+         */
+        'request_key' => 'fields',
+    ],
+];
 ```
 
 ## Usage

--- a/config/fractal.php
+++ b/config/fractal.php
@@ -53,4 +53,20 @@ return [
          */
         'request_key' => 'exclude',
     ],
+
+    'auto_fieldsets' => [
+
+        /*
+         * If enabled Fractal will automatically add the fieldsets who's
+         * names are present in the `fields` request parameter.
+         *
+         * NOTE: This feature does not work if the "resource name" is not set.
+         */
+        'enabled' => true,
+
+        /*
+         * The name of key in the request, where we should look for the fieldsets to parse.
+         */
+        'request_key' => 'fields',
+    ],
 ];

--- a/src/Fractal.php
+++ b/src/Fractal.php
@@ -51,6 +51,14 @@ class Fractal extends Fractalistic
             }
         }
 
+        if (config('fractal.auto_fieldsets.enabled')) {
+            $requestKey = config('fractal.auto_fieldsets.request_key');
+
+            if ($fieldsets = app('request')->get($requestKey)) {
+                $fractal->parseFieldsets($fieldsets);
+            }
+        }
+
         if (empty($serializer)) {
             $serializer = config('fractal.default_serializer');
         }

--- a/tests/AutoFieldsetsTest.php
+++ b/tests/AutoFieldsetsTest.php
@@ -13,7 +13,9 @@ it('returns only requested fields', function ($fields, $expectedMissing) {
     $response->assertOk();
     $response->assertJson(
         fn (AssertableJson $json) => $json->has(
-            'data', 2, fn (AssertableJson $json) => $json->hasAll($fields)
+            'data',
+            2,
+            fn (AssertableJson $json) => $json->hasAll($fields)
             ->missing($expectedMissing),
         ),
     );
@@ -35,7 +37,9 @@ it('doesnt work if "resource name" is not set', function ($fields) {
     $response->assertOk();
     $response->assertJson(
         fn (AssertableJson $json) => $json->has(
-            'data', 2, fn (AssertableJson $json) => $json->hasAll(['id', 'author', 'characters', 'publisher'])
+            'data',
+            2,
+            fn (AssertableJson $json) => $json->hasAll(['id', 'author', 'characters', 'publisher'])
         ),
     );
 })->with([
@@ -53,7 +57,9 @@ it('all fields are present when parameter is not passed', function () {
     $response->assertOk();
     $response->assertJson(
         fn (AssertableJson $json) => $json->has(
-            'data', 2, fn (AssertableJson $json) => $json->hasAll(['id', 'author', 'characters'])
+            'data',
+            2,
+            fn (AssertableJson $json) => $json->hasAll(['id', 'author', 'characters'])
             ->missing('publisher'),
         ),
     );
@@ -72,7 +78,9 @@ it('can be disabled via config', function () {
     $response->assertOk();
     $response->assertJson(
         fn (AssertableJson $json) => $json->has(
-            'data', 2, fn (AssertableJson $json) => $json->hasAll(['id', 'author', 'characters', 'publisher'])
+            'data',
+            2,
+            fn (AssertableJson $json) => $json->hasAll(['id', 'author', 'characters', 'publisher'])
         ),
     );
 });
@@ -91,7 +99,9 @@ it('uses the configured request key', function () {
     $response->assertOk();
     $response->assertJson(
         fn (AssertableJson $json) => $json->has(
-            'data', 2, fn (AssertableJson $json) => $json->has('id')
+            'data',
+            2,
+            fn (AssertableJson $json) => $json->has('id')
             ->missing('author')
         ),
     );

--- a/tests/AutoFieldsetsTest.php
+++ b/tests/AutoFieldsetsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use Illuminate\Testing\Fluent\AssertableJson;
+
+it('returns only requested fields', function ($fields, $expectedMissing) {
+    $response = $this->call('GET', '/auto-fieldsets-with-resource-name', [
+        'fields' => [
+            'books' => $fields,
+        ],
+        'include' => 'characters,publisher',
+    ]);
+
+    $response->assertOk();
+    $response->assertJson(
+        fn (AssertableJson $json) => $json->has(
+            'data', 2, fn (AssertableJson $json) => $json->hasAll($fields)
+            ->missing($expectedMissing),
+        ),
+    );
+})->with([
+    ['author', 'id'],
+    ['id', 'author'],
+    [['author', 'id'], 'publisher'],
+    [['id', 'author', 'publisher'], 'characters'],
+]);
+
+it('doesnt work if "resource name" is not set', function ($fields) {
+    $response = $this->call('GET', '/auto-fieldsets-without-resource-name', [
+        'fields' => [
+            'books' => $fields,
+        ],
+        'include' => 'characters,publisher',
+    ]);
+
+    $response->assertOk();
+    $response->assertJson(
+        fn (AssertableJson $json) => $json->has(
+            'data', 2, fn (AssertableJson $json) => $json->hasAll(['id', 'author', 'characters', 'publisher'])
+        ),
+    );
+})->with([
+    ['author', 'id'],
+    ['id', 'author'],
+    [['author', 'id']],
+    [['id', 'author', 'publisher']],
+]);
+
+it('all fields are present when parameter is not passed', function () {
+    $response = $this->call('GET', '/auto-fieldsets-with-resource-name', [
+        'include' => 'characters',
+    ]);
+
+    $response->assertOk();
+    $response->assertJson(
+        fn (AssertableJson $json) => $json->has(
+            'data', 2, fn (AssertableJson $json) => $json->hasAll(['id', 'author', 'characters'])
+            ->missing('publisher'),
+        ),
+    );
+});
+
+it('can be disabled via config', function () {
+    config()->set('fractal.auto_fieldsets.enabled', false);
+
+    $response = $this->call('GET', '/auto-fieldsets-with-resource-name', [
+        'fields' => [
+            'books' => ['author', 'id'],
+        ],
+        'include' => 'characters,publisher',
+    ]);
+
+    $response->assertOk();
+    $response->assertJson(
+        fn (AssertableJson $json) => $json->has(
+            'data', 2, fn (AssertableJson $json) => $json->hasAll(['id', 'author', 'characters', 'publisher'])
+        ),
+    );
+});
+
+it('uses the configured request key', function () {
+    config()->set('fractal.auto_fieldsets.request_key', 'other_fields');
+    $response = $this->call('GET', '/auto-fieldsets-with-resource-name', [
+        'fields' => [
+            'books' => 'author',
+        ],
+        'other_fields' => [
+            'books' => 'id',
+        ],
+    ]);
+
+    $response->assertOk();
+    $response->assertJson(
+        fn (AssertableJson $json) => $json->has(
+            'data', 2, fn (AssertableJson $json) => $json->has('id')
+            ->missing('author')
+        ),
+    );
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -82,5 +82,20 @@ abstract class TestCase extends Orchestra
                 ->transformWith(TestTransformer::class)
                 ->toArray();
         });
+
+        Route::get('auto-fieldsets-with-resource-name', function () {
+            return fractal()
+                ->withResourceName('books')
+                ->collection($this->testBooks)
+                ->transformWith(TestTransformer::class)
+                ->toArray();
+        });
+
+        Route::get('auto-fieldsets-without-resource-name', function () {
+            return fractal()
+                ->collection($this->testBooks)
+                ->transformWith(TestTransformer::class)
+                ->toArray();
+        });
     }
 }


### PR DESCRIPTION
# Summary
Allow the `fieldsets` to be auto parsed, and configurable similar to the way the [`include`](https://github.com/spatie/laravel-fractal/blob/e9fee265f8e9988bc32b0a7641770a0b2e64590f/src/Fractal.php#L38) and [`exclude`](https://github.com/spatie/laravel-fractal/blob/e9fee265f8e9988bc32b0a7641770a0b2e64590f/src/Fractal.php#L46) features are handled.