### PR TITLE
Add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.4, 8.3, 8.2, 8.1, 8.0]
-        laravel: ['9.*', '10.*', '11.*', '12.*']
+        php: [8.5, 8.4, 8.3, 8.2, 8.1, 8.0]
+        laravel: ['9.*', '10.*', '11.*', '12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -22,6 +22,8 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
           - laravel: 10.*
             php: 8.0
@@ -35,6 +37,16 @@ jobs:
             php: 8.1
           - laravel: 12.*
             php: 8.0
+          - laravel: 13.*
+            php: 8.0
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
+          - laravel: 9.*
+            php: 8.5
+          - laravel: 10.*
+            php: 8.5
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         php: [8.5, 8.4, 8.3, 8.2, 8.1, 8.0]
         laravel: ['9.*', '10.*', '11.*', '12.*', '13.*']
-        dependency-version: [prefer-lowest, prefer-stable]
+        dependency-version: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.2|^10.0|^11.0",
         "pestphp/pest": "^1.22|^2.34|^3.0|^4.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "league/fractal": "^0.20.1|^0.20",
         "nesbot/carbon": "^2.63|^3.0",
         "spatie/fractalistic": "^2.9.5|^2.9",
@@ -31,8 +31,8 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-        "pestphp/pest": "^1.22|^2.34|^3.0"
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^1.22|^2.34|^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Add Laravel 13 support to composer.json and CI
- Add PHP 8.5 to CI matrix
- Add Pest 4 and testbench 11 support

Supersedes #273